### PR TITLE
changed codecompletion keybind, color picker matches vec4 and unmatch…

### DIFF
--- a/app/popup.html
+++ b/app/popup.html
@@ -291,10 +291,10 @@
                     <ul class="keys">
 
                         <li>
-                            <span>Code Completion</span><b>SHIFT + TAB</b>
+                            <span>Code Completion</span><b>CTRL + M</b>
                         </li>
                         <li>
-                            <span>Color Picker</span><b>Cursor on vec3 with 3 numbers</b>
+                            <span>Color Picker</span><b>Cursor on vec3 with r,g,b</b>
                         </li>
                     </ul>
                             <p>On OSX use CMD instead of ALT.</p>


### PR DESCRIPTION
This PR fixes two bugs -- it changes the keybinding for codecompletion to ctrl-m so that I don't overwrite shift-tab (used for unindent), and the color picker now matches vec4 and unmatches ivec3, uvec3 and bvec3.