### PR TITLE
Shorten links by removing locales and display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ ShaderToy unofficial plugin is a web extension designed to enhance the coding ex
 
 ## Stores:
 
-[Chrome extension](https://chrome.google.com/webstore/detail/shadertoy-unofficial-plug/ohicbclhdmkhoabobgppffepcopomhgl?hl=pl)
+[Chrome extension](https://chrome.google.com/webstore/detail/ohicbclhdmkhoabobgppffepcopomhgl)
 
-[Firefox add-on](https://addons.mozilla.org/en-US/firefox/addon/shadertoy-unofficial-plugin/)
+[Firefox add-on](https://addons.mozilla.org/firefox/addon/shadertoy-unofficial-plugin/)
 
 [Microsoft Edge extension](https://microsoftedge.microsoft.com/addons/detail/mjcddpebilehgjibahdplabcocgpfmdb)
 


### PR DESCRIPTION
The only real improvement here is that the chrome web store page won't open in polish anymore. I believe mozilla would've redirected you to the correct language, but I removed the part that specifies the language there too. I also removed the name of the extension from the chrome URL, just like it was with the ms edge one, for consistency and concisity I guess.