### PR TITLE
Create Makefile based on GitHub Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,5 @@ jobs:
           name: output
 
       - name: Publish Release on GitHub
-        run: |
-          VERSION=$(awk '{printf "%s", $0}' ./manifests/version.txt)
-          gh release create $VERSION ./output/ShaderToy-Chrome-Plugin-$VERSION.zip ./output/ShaderToy-Firefox-Plugin-$VERSION.zip --title "$VERSION" --notes "Release of version $VERSION (Chrome)"
+        run: make release
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,35 +14,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cleanup
-        run: |
-          rm -rf output
-
-      - name: Prepare output directory
-        run: |
-          mkdir -p output
-          mkdir -p output/chrome
-          mkdir -p output/firefox
-          VERSION=$(awk '{printf "%s", $0}' ./manifests/version.txt)
-          echo $VERSION
+        run: make clean
 
       - name: Zip the Chrome extension
-        run: |
-          VERSION=$(awk '{printf "%s", $0}' ./manifests/version.txt)
-          cp ./app/* ./output/chrome -r
-          cp ./manifests/manifest-chrome.json ./output/chrome/manifest.json
-          jq --arg version "$VERSION" '.version = $version' ./output/chrome/manifest.json > ./output/chrome/manifest.json.tmp && mv ./output/chrome/manifest.json.tmp ./output/chrome/manifest.json
-          zip -r ./output/ShaderToy-Chrome-Plugin-$VERSION.zip ./output/chrome
+        run: make zip-chrome
 
       - name: Zip the Firefox extension
         env:
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXT_ID }}
-        run: |
-          VERSION=$(awk '{printf "%s", $0}' ./manifests/version.txt)
-          cp ./app/* ./output/firefox -r
-          cp ./manifests/manifest-firefox.json ./output/firefox/manifest.json
-          jq --arg id "$FIREFOX_EXTENSION_ID" '.browser_specific_settings.gecko.id = $id' ./output/firefox/manifest.json > ./output/firefox/manifest.json.tmp && mv ./output/firefox/manifest.json.tmp ./output/firefox/manifest.json
-          jq --arg version "$VERSION" '.version = $version' ./output/firefox/manifest.json > ./output/firefox/manifest.json.tmp && mv ./output/firefox/manifest.json.tmp ./output/firefox/manifest.json
-          zip -r ./output/ShaderToy-Firefox-Plugin-$VERSION.zip ./output/firefox
+        run: make zip-firefox
 
       - name: Upload output as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,7 @@ jobs:
           FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
           FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
 
-        run: |
-          VERSION=$(awk '{printf "%s", $0}' ./manifests/version.txt)
-          npx publish-extension \
-            --chrome-zip ./output/ShaderToy-Chrome-Plugin-$VERSION.zip \
-            --firefox-zip ./output/ShaderToy-Firefox-Plugin-$VERSION.zip
+        run: make publish
 
   release:
     runs-on: self-hosted

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,5 +71,5 @@ jobs:
           name: output
 
       - name: Publish Release on GitHub
-        run: make release
+        run: make github-release
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.swp
 *~
 ~*
+output

--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,3 @@ release: zip
 		$(OUT_DIR)/ShaderToy-Chrome-Plugin-$(VERSION).zip \
 		$(OUT_DIR)/ShaderToy-Firefox-Plugin-$(VERSION).zip \
 		--title "$(VERSION)"
-		--notes "Release of version $(VERSION) (Chrome)"

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,9 @@ github-release: zip
 		$(OUT_DIR)/ShaderToy-Chrome-Plugin-$(VERSION).zip \
 		$(OUT_DIR)/ShaderToy-Firefox-Plugin-$(VERSION).zip \
 		--title "$(VERSION)"
+
+publish: zip
+	@echo "Publishing extensions"
+	npx publish-extension \
+		--chrome-zip $(OUT_DIR)/ShaderToy-Chrome-Plugin-$(VERSION).zip \
+		--firefox-zip $(OUT_DIR)/ShaderToy-Firefox-Plugin-$(VERSION).zip

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-# --------------------------------------------------------------------
-# Variables
-# --------------------------------------------------------------------
 VERSION         := $(shell awk '{printf "%s", $$0}' ./manifests/version.txt)
 APP_DIR         := ./app
 MANIFESTS_DIR   := ./manifests

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BROWSERS        := chrome firefox
 # Capitalize the first letter of the browser name for the ZIP file name
 capitalize_first = $(shell echo $(1) | sed 's/.*/\u&/')
 
-.PHONY: all clean zip prepare-% clean-% zip-%
+.PHONY: all clean zip prepare-% clean-% zip-% github-release publish
 
 all: zip
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+# --------------------------------------------------------------------
+# Variables
+# --------------------------------------------------------------------
+VERSION         := $(shell awk '{printf "%s", $$0}' ./manifests/version.txt)
+APP_DIR         := ./app
+MANIFESTS_DIR   := ./manifests
+OUT_DIR         := ./output
+
+# Space separated list of browsers to build for.
+# Of course, functionality will have to be adjusted, this ain't magic.
+BROWSERS        := chrome firefox
+
+# Capitalize the first letter of the browser name for the ZIP file name
+capitalize_first = $(shell echo $(1) | sed 's/.*/\u&/')
+
+.PHONY: all clean zip prepare-% clean-% zip-%
+
+all: zip
+
+clean:
+	@echo "Cleaning all zip files"
+	rm -rf $(OUT_DIR)
+
+zip: $(BROWSERS:%=zip-%)
+
+# clean-<browser>
+clean-%:
+	@echo "Cleaning build files for $* browser"
+	rm -rf $(OUT_DIR)/$* \
+			$(OUT_DIR)/ShaderToy-$(call capitalize_first,$*)-Plugin-*.zip
+
+# prepare-<browser>
+prepare-%: clean-%
+	@echo "Preparing build for $* browser"
+	mkdir -p $(OUT_DIR)/$*
+ifeq ($*,firefox)
+ifndef FIREFOX_EXTENSION_ID
+	$(error Please set the FIREFOX_EXTENSION_ID environment variable)
+endif
+endif
+
+# zip-<browser>
+zip-%: prepare-%
+	@echo "Building zip file of version $(VERSION) for $* browser"
+	cp -r $(APP_DIR)/* $(OUT_DIR)/$*
+	cp $(MANIFESTS_DIR)/manifest-$*.json $(OUT_DIR)/$*/manifest.json
+	jq '.version = "$(VERSION)"' $(OUT_DIR)/$*/manifest.json \
+		> $(OUT_DIR)/$*/manifest.json.tmp
+	mv $(OUT_DIR)/$*/manifest.json.tmp $(OUT_DIR)/$*/manifest.json
+
+ifeq ($*,firefox)
+	jq '.applications.gecko.id = "$(FIREFOX_EXTENSION_ID)"' $(OUT_DIR)/$*/manifest.json \
+		> $(OUT_DIR)/$*/manifest.json.tmp
+	mv $(OUT_DIR)/$*/manifest.json.tmp $(OUT_DIR)/$*/manifest.json
+endif
+
+	zip -r \
+	  $(OUT_DIR)/ShaderToy-$(call capitalize_first,$*)-Plugin-$(VERSION).zip \
+	  $(OUT_DIR)/$*

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 	  ../../$(OUT_DIR)/ShaderToy-$(call capitalize_first,$*)-Plugin-$(VERSION).zip \
 	  ./*
 
-release: zip
+github-release: zip
 	@echo "Creating GitHub release for version $(VERSION)"
 	echo release create $(VERSION) \
 		$(OUT_DIR)/ShaderToy-Chrome-Plugin-$(VERSION).zip \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifeq ($*,firefox)
 		> $(OUT_DIR)/$*/manifest.json.tmp
 	mv $(OUT_DIR)/$*/manifest.json.tmp $(OUT_DIR)/$*/manifest.json
 endif
-
+	cd $(OUT_DIR)/$* && \
 	zip -r \
-	  $(OUT_DIR)/ShaderToy-$(call capitalize_first,$*)-Plugin-$(VERSION).zip \
-	  $(OUT_DIR)/$*
+	  ../../$(OUT_DIR)/ShaderToy-$(call capitalize_first,$*)-Plugin-$(VERSION).zip \
+	  ./*

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,11 @@ endif
 	zip -r \
 	  ../../$(OUT_DIR)/ShaderToy-$(call capitalize_first,$*)-Plugin-$(VERSION).zip \
 	  ./*
+
+release: zip
+	@echo "Creating GitHub release for version $(VERSION)"
+	echo release create $(VERSION) \
+		$(OUT_DIR)/ShaderToy-Chrome-Plugin-$(VERSION).zip \
+		$(OUT_DIR)/ShaderToy-Firefox-Plugin-$(VERSION).zip \
+		--title "$(VERSION)"
+		--notes "Release of version $(VERSION) (Chrome)"


### PR DESCRIPTION
This makes the CI/CD code more readable, maintainable and accessible for running locally.

I have combined the similar zip workflows into one parameterized make command. It is almost identical in functionality and has the same results, except for some opinionated changes I made, which can be reversed if you disagree:
- ~~The final zip files previously had their actual contents wrapped inside `output/<browser>/`, they are now at the root.~~
This has been changed in upstream independently
- Release notes were previously `Release of version <version> (Chrome)`. This is inaccurate, as the releases contain files for both browsers. Just having the release note `Release of version <version>` would be entirely redundant, so I left it out.