### PR TITLE
Fix incorrect resolution multiplier

### DIFF
--- a/app/shadertoy-plugin.js
+++ b/app/shadertoy-plugin.js
@@ -323,8 +323,8 @@
         multiplyRes(multiplier) {
             var b = this.c.getBoundingClientRect(),
                 n = {
-                    w: Math.floor(b.width * multiplier),
-                    h: Math.floor(b.height * multiplier)
+                    w: Math.floor(b.width * multiplier * window.devicePixelRatio),
+                    h: Math.floor(b.height * multiplier * window.devicePixelRatio)
                 };
 
             var mE = gShaderToy.mEffect;


### PR DESCRIPTION
Before, if `window.devicePixelRatio` wasn't `1`, then hitting `Alt`+`1` didn't reset the resolution to the correct size. Now it should be correct.

Fixes #194