### PR TITLE
new splitter on view screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# ShaderToy unofficial plugin.
+# ShaderToy unofficial plugin
 
-ShaderToy unofficial plugin is a web extension designed to enhance the coding experience for users of Shadertoy.
+ShaderToy unofficial plugin is a web extension designed to enhance the coding experience for users of [Shadertoy](http://shadertoy.com/).
 
-# Installing:
-
-## Stores:
+## Installation via Stores
 
 [Chrome extension](https://chrome.google.com/webstore/detail/ohicbclhdmkhoabobgppffepcopomhgl)
 
@@ -12,69 +10,71 @@ ShaderToy unofficial plugin is a web extension designed to enhance the coding ex
 
 [Microsoft Edge extension](https://microsoftedge.microsoft.com/addons/detail/mjcddpebilehgjibahdplabcocgpfmdb)
 
-## Manual installation
+## Manual Installation
 
 Download latest **zip** from [Releases](https://github.com/patuwwy/ShaderToy-Chrome-Plugin/releases)
 
-## Google Chrome
+### Google Chrome
 
 1. Download the extension from the provided link and unzip it.
 2. Open Chrome and go to `chrome://extensions/`.
 3. In the top right corner, enable developer mode.
 4. Drag and drop downloaded file.
 
-## Mozilla Firefox
+### Mozilla Firefox
 
 1. Download the extension from the provided link and unzip it.
 2. Open Firefox and go to `about:debugging`.
 3. Click `This Firefox`.
 4. Click `Load Temporary Add-on…` and select the manifest.json file in the folder with the unpacked extension.
 
-## Microsoft Edge
+### Microsoft Edge
 
 1. Download the extension from the provided link and unzip it.
 2. Open Edge and go to `edge://extensions/`.
 3. In the top right corner, enable developer mode.
 4. Click `Load unpacked` and select the folder with the unpacked extension.
 
-# Privacy Policy
+## Privacy Policy
 
 Privacy policy is available [here](https://github.com/patuwwy/ShaderToy-Chrome-Plugin/blob/master/PRIVACY-POLICY.md)
 
-## Contribution:
+## Contribution
 
 Please report bugs and request features [here](https://github.com/patuwwy/ShaderToy-Chrome-Plugin/issues).
 
 Please add issue with description before PR.
 
-## Features:
+## Features
 
--   **Custom parameters** -
+* **View splitter** to resize the view and code columns. Double -lick the splitter to restore the default, or right-click to remove it.
+
+* **Custom parameters** -
     [See documentation](./docs/custom-params.md)
 
--   **Fork** any shader.
+* **Fork** any shader.
 
--   **GPU render timers** (EXT_disjoint_timer_query_webgl2).
+* **GPU render timers** (EXT_disjoint_timer_query_webgl2).
 
--   Adjustable slider for **full control of 'iTime'** uniform and audio/video channels' time.
+* Adjustable slider for **full control of 'iTime'** uniform and audio/video channels' time.
 
--   Save as new draft (for owned shaders).
+* Save as new draft (for owned shaders).
 
--   Four sliders for **simulating mouse position**.
+* Four sliders for **simulating mouse position**.
     This can be used to tweaking variables with iMouse.xyzw uniform.
 
--   ~~Switchable dark color theme.~~
+* ~~Switchable dark color theme.~~
     (feature removed - implemented natively in Shadertoy)
 
--   ~~Sorting shaders list by views, likes or comments on "My profile" page.~~
+* ~~Sorting shaders list by views, likes or comments on "My profile" page.~~
     (feature removed - implemented natively in Shadertoy)
 
--   Alternative shaders list on profile page. ~~(chrome only)~~
+* Alternative shaders list on profile page. ~~(chrome only)~~
 
--   ~~Shaders previews on "My profile" page.~~
+* ~~Shaders previews on "My profile" page.~~
     (feature removed - implemented natively in Shadertoy. Big preview on mouse over is still available)
 
--   **Change resolution** in windowed and fullscreen mode by pressing keys ALT + 1...9.
+* **Change resolution** in windowed and fullscreen mode by pressing keys ALT + 1...9.
 
     Resolution is divided by pressed key value, for example:
 
@@ -86,84 +86,86 @@ Please add issue with description before PR.
     Notice, antialiasing is enabled by default on Shadertoy WebGL canvas.
     For "pixelated" image, rendering mode switch has been added in extension's popup (click on green S icon) ~~(chrome only)~~.
 
--   Take HQ screenshot. Screenshot resolution is 2 \* current resolution (including current resolution divider). 1920x1080 becomes 3840x2160.
+* Take HQ screenshot. Screenshot resolution is 2 \* current resolution (including current resolution divider). 1920x1080 becomes 3840x2160.
 
--   Pause/Restart in fullscreen mode.
+* Pause/Restart in fullscreen mode.
 
--   Fullscreen edit mode.
+* Fullscreen edit mode.
 
--   **Export shaders** (single JSON or ZIP archive with JSON and readme.txt).
+* **Export shaders** (single JSON or ZIP archive with JSON and readme.txt).
 
--   Import JSON.
+* Import JSON.
 
--   **Show links** in description/comments even if not inserted with BBCode.
+* **Show links** in description/comments even if not inserted with BBCode.
 
--   ~~Show current canvas resolution~~ ~~on FPS hover~~
+* ~~Show current canvas resolution~~ ~~on FPS hover~~
     (feature removed - implemented natively in Shadertoy)
 
--   **Render call multiplier**.
+* **Render call multiplier**.
 
--   **Loop** in set time range (including video/audio channels).
+* **Loop** in set time range (including video/audio channels).
 
--   **Open recent** - Quick access to recently viewed own shaders.
+* **Open recent** - Quick access to recently viewed own shaders.
 
--   Shader preview (automatic generated image).
+* Shader preview (automatic generated image).
 
--   **Code completion** for glsl keywords in the code editor.
+* **Code completion** for glsl keywords in the code editor.
 
--   **Color picker** for any vec3 with r,g,b values in the code editor.
+* **Color picker** for any vec3 with r,g,b values in the code editor.
 
 ## Screenshots
 
 ### Controls
 
-##### Setting iMouse.xyzw uniform:
+#### Setting iMouse.xyzw uniform
 
-![](./screenshots/mouse.png)
+![Setting iMouse.xyzw uniform](./screenshots/mouse.png)
 
-##### Setting iTime uniform. You can set the start and end time range and toggle loop:
+##### Setting iTime uniform
 
-![](./screenshots/shader-edit.png)
+You can set the start and end time range and toggle loop
+
+![Setting iTime uniform](./screenshots/shader-edit.png)
 
 ---
 
 ### Alternative shader list on profile page
 
-##### Displays your shaders, grouped by status, as a lists of images with title:
+* Displays your shaders, grouped by status, as a lists of images with title
 
-![](./screenshots/alternate-profile.png)
+![alternative profile](./screenshots/alternate-profile.png)
 
 ---
 
 ### Info popup
 
-##### Key bindings, render mode and alternate profile page switch:
+* Key bindings, render mode and alternate profile page switch
 
-![](./screenshots/popup.png)
+![Info popup](./screenshots/popup.png)
 
 ---
 
 ### Code editor
 
-##### Color picker for any vec3 with r,g,b
+* Color picker for any vec3 with r,g,b
 
-![](./screenshots/color-picker.png)
+![Color picker](./screenshots/color-picker.png)
 
-##### Code completion for glsl keywords and code snippets
+* Code completion for glsl keywords and code snippets
 
-![](./screenshots/code-completion.png)
+![Code completion](./screenshots/code-completion.png)
 
-##### BBCode buttons to make writing comments easier
+* BBCode buttons to make writing comments easier
 
-![](./screenshots/bbcode-buttons.png)
+![BBCode buttons](./screenshots/bbcode-buttons.png)
 
 ---
 
-## Author / Contact:
+## Author / Contact
 
 [PatrykFalba (Patu)](http://patrykfalba.pl)
 
-## Contributors:
+## Contributors
 
 [movAX13h](http://blog.thrill-project.com/)
 
@@ -177,6 +179,6 @@ Render timing based on [shadertoy_gpu_timing.user.js](https://github.com/andrei-
 
 If you find this extension useful, I'd love to hug :beer: via [PayPal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VDFNBT9N3ANHW&source=url)
 
-## Changelog:
+## Changelog
 
 Most recent changelog is [here](https://github.com/patuwwy/ShaderToy-Chrome-Plugin/blob/master/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please add issue with description before PR.
 
 ## Features
 
-* **View splitter** to resize the view and code columns. Double -lick the splitter to restore the default, or right-click to remove it.
+* **View splitter** to resize the view and code columns. Double-click the splitter to restore the default, or right-click to remove it.
 
 * **Custom parameters** -
     [See documentation](./docs/custom-params.md)

--- a/app/shadertoy-splitter.js
+++ b/app/shadertoy-splitter.js
@@ -129,17 +129,21 @@
 
     // Initialize handle near the existing column boundary if possible
     (function tryAlignToCurrentColumns() {
-        const parts = startCols.split(/\s+/);
+        const parts = splitTracks(startCols);
         const rect = container.getBoundingClientRect();
         const total = rect.width;
         let leftGuess = total / 2;
 
         function parseLen(val, fallback) {
             if (val.endsWith('px')) return parseFloat(val);
-            if (val.endsWith('fr')) return total * (parseFloat(val) / parts
-                .filter(v => v.endsWith('fr'))
-                .map(v => parseFloat(v))
-                .reduce((a, b) => a + b, 0));
+            if (val.endsWith('fr')) {
+                const totalFr = parts
+                    .filter(v => v.endsWith('fr'))
+                    .map(v => parseFloat(v))
+                    .reduce((a, b) => a + b, 0);
+                if (totalFr === 0) return fallback;
+                return total * (parseFloat(val) / totalFr);
+            }
             if (val.endsWith('%')) return total * (parseFloat(val) / 100);
             return fallback;
         }

--- a/app/shadertoy-splitter.js
+++ b/app/shadertoy-splitter.js
@@ -1,0 +1,249 @@
+(function () {
+    const container = document.querySelector('.container');
+    if (!container) return console.error('No .container found');
+
+    // Require at least two children to split
+    const kids = Array.from(container.children);
+    if (kids.length < 2) return console.error('.container needs at least two child elements');
+
+    const splitterWidth = 4;
+    const minLeft = 80;      // px, minimum left pane
+    const minRight = 80;     // px, minimum right pane
+
+    // Cache original settings so this is reversible
+    const original = {
+        display: container.style.display,
+        gridTemplateColumns: container.style.gridTemplateColumns,
+        position: container.style.position,
+    };
+
+    // Make sure it’s a grid and positionable
+    const cs = getComputedStyle(container);
+    if (cs.display !== 'grid') container.style.display = 'grid';
+    if (cs.position === 'static' || !cs.position) container.style.position = 'relative';
+
+    // Pin first two children to columns 1 and 3 (we’ll create 3 tracks)
+    const leftEl = kids[0];
+    const rightEl = kids[1];
+    leftEl.style.gridColumn = '1';
+    rightEl.style.gridColumn = '3';
+
+    // Use the current template if it exists; otherwise assume two cols.
+    // We need to split by spaces but NOT inside parentheses (e.g. minmax(), repeat()).
+    function splitTracks(str) {
+        const out = [];
+        let buf = '';
+        let depth = 0;
+        for (const ch of str.trim()) {
+            if (ch === '(') depth++;
+            if (ch === ')') depth = Math.max(0, depth - 1);
+            if (ch === ' ' && depth === 0) {
+                if (buf) { out.push(buf); buf = ''; }
+            } else {
+                buf += ch;
+            }
+        }
+        if (buf) out.push(buf);
+        return out;
+    }
+
+    let startCols = cs.gridTemplateColumns.trim();
+    let leftTrack = '1fr', rightTrack = '1fr';
+
+    if (startCols) {
+        const tokens = splitTracks(startCols);
+        if (tokens.length >= 2) {
+            leftTrack = tokens[0];
+        }
+    }
+
+    // Create three tracks: left | splitter | right (preserve original left/right)
+    container.style.gridTemplateColumns = `${leftTrack} ${splitterWidth}px auto`;
+    container.style.gridGap = '14px';
+
+    // If a previous splitter exists, remove it first
+    const old = container.querySelector('#grid-splitter');
+    if (old) old.remove();
+
+    // Build the visible handle (absolute so it always catches events)
+    const handle = document.createElement('div');
+    handle.id = 'grid-splitter';
+    Object.assign(handle.style, {
+        position: 'absolute',
+        top: '0',
+        bottom: '0',
+        width: splitterWidth + 'px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        cursor: 'col-resize',
+        background: '#777777',
+        opacity: '1',
+        transition: 'background 0.15s ease, opacity 1s ease',
+        zIndex: '9999',
+        userSelect: 'none'
+    });
+    handle.addEventListener('mouseenter', () => {
+        handle.style.background = '#777777';
+        handle.style.opacity = '1';
+    });
+
+    handle.addEventListener('mouseleave', () => {
+        handle.style.background = '#777777';
+        if (!dragging) setTimeout(() => { handle.style.opacity = '0'; }, 500);
+    });
+    container.appendChild(handle);
+    // Show for 1s, then fade out over 1s
+    setTimeout(() => { handle.style.opacity = '0'; }, 1000);
+
+
+    // Floating readout showing column widths during drag
+    const readout = document.createElement('div');
+    Object.assign(readout.style, {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        transform: 'translate(12px, 12px)', // offset from pointer via JS position
+        padding: '4px 8px',
+        font: '12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif',
+        background: 'rgba(0,0,0,0.8)',
+        color: '#fff',
+        borderRadius: '6px',
+        pointerEvents: 'none',
+        zIndex: '10000',
+        display: 'none',
+        whiteSpace: 'nowrap',
+        boxShadow: '0 2px 6px rgba(0,0,0,0.35)'
+    });
+    document.body.appendChild(readout);
+
+    // Utility to set columns from an x position (px from container left)
+    function setColumnsFromX(x) {
+        const rect = container.getBoundingClientRect();
+        const total = rect.width;
+        const left = Math.max(minLeft, Math.min(x, total - minRight - splitterWidth));
+        const right = Math.max(minRight, total - left - splitterWidth);
+        container.style.gridTemplateColumns = `${left}px ${splitterWidth}px auto`;
+        handle.style.left = (left + splitterWidth / 2) + 'px';
+        return { left, right, total };
+    }
+
+    // Initialize handle near the existing column boundary if possible
+    (function tryAlignToCurrentColumns() {
+        const parts = startCols.split(/\s+/);
+        const rect = container.getBoundingClientRect();
+        const total = rect.width;
+        let leftGuess = total / 2;
+
+        function parseLen(val, fallback) {
+            if (val.endsWith('px')) return parseFloat(val);
+            if (val.endsWith('fr')) return total * (parseFloat(val) / parts
+                .filter(v => v.endsWith('fr'))
+                .map(v => parseFloat(v))
+                .reduce((a, b) => a + b, 0));
+            if (val.endsWith('%')) return total * (parseFloat(val) / 100);
+            return fallback;
+        }
+
+        if (parts.length >= 2) {
+            const guess = parseLen(parts[0], leftGuess);
+            if (isFinite(guess) && guess > 0 && guess < total) leftGuess = guess;
+        }
+        setColumnsFromX(leftGuess);
+    })();
+
+    // --- Drag handlers ---
+    let dragging = false;
+    let dragOffset = 0;
+
+    function updateReadout(clientX, clientY, sizes) {
+        if (!sizes) return;
+        const { left, right, total } = sizes;
+        const lp = Math.round((left / total) * 100);
+        const rp = Math.round((right / total) * 100);
+        readout.textContent = `${Math.round(left)}px (${lp}%) | ${Math.round(right)}px (${rp}%)`;
+        readout.style.left = clientX + 'px';
+        readout.style.top = clientY + 'px';
+    }
+
+    function onDown(e) {
+        dragging = true;
+        handle.style.opacity = '1';
+        document.body.style.cursor = 'col-resize';
+        e.preventDefault();
+        const rect = handle.getBoundingClientRect();
+        dragOffset = e.clientX - (rect.left + rect.width / 2);
+        readout.style.display = 'block';
+    }
+
+    function onMove(e) {
+        if (!dragging) return;
+        const cRect = container.getBoundingClientRect();
+        const sizes = setColumnsFromX(e.clientX - cRect.left - dragOffset);
+        updateReadout(e.clientX, e.clientY, sizes);
+    }
+
+    function onUp() {
+        if (!dragging) return;
+        dragging = false;
+        document.body.style.cursor = '';
+        readout.style.display = 'none';
+        setTimeout(() => { handle.style.opacity = '0'; }, 500);
+    }
+
+    handle.addEventListener('mousedown', onDown);
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+
+    // Touch support
+    handle.addEventListener('touchstart', (e) => {
+        const t = e.touches[0];
+        dragging = true;
+        document.body.style.cursor = 'col-resize';
+        const rect = handle.getBoundingClientRect();
+        dragOffset = t.clientX - (rect.left + rect.width / 2);
+        readout.style.display = 'block';
+        e.preventDefault();
+    }, { passive: false });
+
+    window.addEventListener('touchmove', (e) => {
+        if (!dragging) return;
+        const t = e.touches[0];
+        const cRect = container.getBoundingClientRect();
+        const sizes = setColumnsFromX(t.clientX - cRect.left - dragOffset);
+        updateReadout(t.clientX, t.clientY, sizes);
+    }, { passive: false });
+
+    window.addEventListener('touchend', onUp);
+
+    // Double-click to reset to 50/50
+    handle.addEventListener('dblclick', () => {
+        const rect = container.getBoundingClientRect();
+        const sizes = setColumnsFromX((rect.width - splitterWidth) / 2);
+        // Center readout briefly at handle
+        updateReadout(rect.left + rect.width / 2, rect.top + 24, sizes);
+    });
+
+    // Right-click (context menu) on the bar should remove it and restore layout
+    function removeSplitter() {
+        // Clean listeners
+        handle.removeEventListener('mousedown', onDown);
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+        handle.removeEventListener('touchstart', onDown);
+        window.removeEventListener('touchmove', onMove);
+        window.removeEventListener('touchend', onUp);
+
+        // Remove UI elements
+        if (handle.parentNode) handle.parentNode.removeChild(handle);
+        if (readout.parentNode) readout.parentNode.removeChild(readout);
+
+        // console.log('Splitter removed.');
+    }
+
+    handle.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+        removeSplitter();
+    });
+
+    //  console.log('Splitter attached. Drag the visible bar to resize. Right‑click it to remove.');
+})();

--- a/app/shadertoy-splitter.js
+++ b/app/shadertoy-splitter.js
@@ -89,11 +89,11 @@
 
     handle.addEventListener('mouseleave', () => {
         handle.style.background = '#777777';
-        if (!dragging) setTimeout(() => { handle.style.opacity = '0'; }, 500);
+        handle.style.opacity = '0';
     });
     container.appendChild(handle);
     // Show for 1s, then fade out over 1s
-    setTimeout(() => { handle.style.opacity = '0'; }, 1000);
+    setTimeout(() => { handle.style.opacity = '0'; }, 500);
 
 
     // Floating readout showing column widths during drag
@@ -177,6 +177,7 @@
 
     function onMove(e) {
         if (!dragging) return;
+        handle.style.opacity = '1';
         const cRect = container.getBoundingClientRect();
         const sizes = setColumnsFromX(e.clientX - cRect.left - dragOffset);
         updateReadout(e.clientX, e.clientY, sizes);
@@ -187,7 +188,7 @@
         dragging = false;
         document.body.style.cursor = '';
         readout.style.display = 'none';
-        setTimeout(() => { handle.style.opacity = '0'; }, 500);
+        handle.style.opacity = '0'; 
     }
 
     handle.addEventListener('mousedown', onDown);

--- a/manifests/manifest-chrome.json
+++ b/manifests/manifest-chrome.json
@@ -23,6 +23,11 @@
             "js": ["contentscript.js"],
             "css": ["style.css"],
             "run_at": "document_end"
+        },
+        {
+            "matches": ["https://www.shadertoy.com/view/*"],
+            "js": ["shadertoy-splitter.js"],
+            "run_at": "document_end"
         }
     ],
     "web_accessible_resources": [
@@ -40,6 +45,7 @@
                 "add-ons/monaco/min/vs/base/worker/workerMain.js",
                 "shadertoy-plugin-profile.js",
                 "shadertoy-plugin-home.js",
+                "shadertoy-splitter.js",
                 "scripts/jszip-3.1.5.js",
                 "scripts/node-sanitize-filename.js"
             ],

--- a/manifests/manifest-firefox.json
+++ b/manifests/manifest-firefox.json
@@ -30,6 +30,11 @@
             "js": ["contentscript.js"],
             "css": ["style.css"],
             "run_at": "document_end"
+        },
+        {
+            "matches": ["https://www.shadertoy.com/view/*"],
+            "js": ["shadertoy-splitter.js"],
+            "run_at": "document_end"
         }
     ],
     "web_accessible_resources": [
@@ -47,6 +52,7 @@
                 "add-ons/monaco/min/vs/base/worker/workerMain.js",
                 "shadertoy-plugin-profile.js",
                 "shadertoy-plugin-home.js",
+                "shadertoy-splitter.js",
                 "scripts/jszip-3.1.5.js",
                 "scripts/node-sanitize-filename.js"
             ],


### PR DESCRIPTION
Makes it easy to resize the view and code columns. Double-click the splitter to restore the default, or right-click to remove it.
