### PR TITLE
prevent clipping of paint calls number

### DIFF
--- a/app/style.css
+++ b/app/style.css
@@ -347,7 +347,7 @@ body.alternate-profile div#header {
     background-color: rgb(25, 103, 160);
     color: #fff;
     margin-left: 10px;
-    min-width: 45px;
+    min-width: 50px;
 }
 
 .ste-min-input,


### PR DESCRIPTION
If you use the extension as it is right now, double digit numbers are cut off when selected. Increasing width by 5 pixels fixes it
old:
<img width="139" height="38" alt="image" src="https://github.com/user-attachments/assets/c44ab226-31a1-4622-9e41-f3a9272e8c73" />
new:
<img width="145" height="40" alt="image" src="https://github.com/user-attachments/assets/47b7713b-b743-419c-b66a-71af55185174" />
